### PR TITLE
Correcting caddyfile validation errors

### DIFF
--- a/.github/workflows/validate-caddyfile.yml
+++ b/.github/workflows/validate-caddyfile.yml
@@ -1,0 +1,49 @@
+name: Validate Caddyfile
+
+on:
+  push:
+    branches: [ master, main ]
+    paths: [ 'Caddyfile' ]
+  pull_request:
+    branches: [ master, main ]
+    paths: [ 'Caddyfile' ]
+  workflow_dispatch:
+
+jobs:
+  validate-caddy:
+    name: Validate Caddyfile Configuration
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install Caddy
+      run: |
+        sudo apt update
+        sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+        curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+        sudo apt update
+        sudo apt install caddy
+        
+    - name: Validate Caddyfile
+      run: |
+        echo "Validating Caddyfile configuration..."
+        caddy validate --config ./Caddyfile
+        echo "✅ Caddyfile is valid!"
+        
+    - name: Format check (optional)
+      run: |
+        echo "Checking Caddyfile formatting..."
+        # Create a temporary formatted file to compare
+        cp Caddyfile Caddyfile.tmp
+        caddy fmt --overwrite Caddyfile.tmp
+        if ! diff -q Caddyfile Caddyfile.tmp > /dev/null; then
+          echo "⚠️  Caddyfile could be formatted better. Run 'caddy fmt --overwrite' to fix."
+          echo "Differences:"
+          diff Caddyfile Caddyfile.tmp || true
+        else
+          echo "✅ Caddyfile formatting is good!"
+        fi
+        rm -f Caddyfile.tmp

--- a/Caddyfile
+++ b/Caddyfile
@@ -6,7 +6,7 @@
 }
 
 # Define the HTTP server
-http://:{$SERVER_PORT:-8080} {
+:{$SERVER_PORT:8080} {
     log {
         output stderr
         level  DEBUG
@@ -24,8 +24,6 @@ http://:{$SERVER_PORT:-8080} {
         # Prepend BUCKET_PATH_PREFIX/data to the incoming request URI path
         rewrite * {$BUCKET_PATH_PREFIX}/data{http.request.uri.path}
         
-        log { level DEBUG; msg "Main handle: Original URI '{http.request.orig_uri.path}', Rewritten to '{http.request.uri.path}' for proxying to {$MINIO_UPSTREAM_URL}."}
-        
         reverse_proxy {$MINIO_UPSTREAM_URL} {
             header_up Host {http.reverse_proxy.upstream.hostport}
         }
@@ -35,17 +33,17 @@ http://:{$SERVER_PORT:-8080} {
     handle_errors {
         @spa_fallback expression {http.error.status_code} == 403 || {http.error.status_code} == 404
         handle @spa_fallback {
-            log { level DEBUG; msg "handle_errors SPA Fallback: Error {http.error.status_code} for original request '{http.request.orig_uri.path}'. Rewriting to SPA entry point '{$BUCKET_PATH_PREFIX}/data{$SPA_ENTRYPOINT_PATH}' and proxying to {$MINIO_UPSTREAM_URL}."}
-            
             # Rewrite to the SPA entry point, assuming it's also under the 'data' prefix in S3.
             # e.g., if SPA_ENTRYPOINT_PATH is /index.html, this becomes /frontend-assets/data/index.html
-            rewrite * {$BUCKET_PATH_PREFIX}/data{$SPA_ENTRYPOINT_PATH:-/index.html}
+            rewrite * {$BUCKET_PATH_PREFIX}/data{$SPA_ENTRYPOINT_PATH:/index.html}
             
             reverse_proxy {$MINIO_UPSTREAM_URL} {
                 header_up Host {http.reverse_proxy.upstream.hostport}
             }
         }
         # For other errors not handled by SPA fallback
-        respond "{http.error.status_code} {http.error.status_text}" { close }
+        respond "{http.error.status_code} {http.error.status_text}" {
+            close
+        }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   minio:
     image: minio/minio:latest
@@ -10,8 +8,8 @@ services:
     volumes:
       - minio_data:/data # Docker named volume for persistence
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
     command: server /data --console-address ":9001"
     networks:
       - caddy_test_net
@@ -32,13 +30,13 @@ services:
       minio:
         condition: service_healthy # Wait for Minio to be healthy
     environment:
-      - SERVER_PORT=8080
+      SERVER_PORT: "8080"
       # MINIO_UPSTREAM_URL uses the service name 'minio' from this docker-compose file
-      - MINIO_UPSTREAM_URL=http://minio:9000 
-      - BUCKET_PATH_PREFIX=/frontend-assets
+      MINIO_UPSTREAM_URL: "http://minio:9000"
+      BUCKET_PATH_PREFIX: "/frontend-assets"
       # SPA_ENTRYPOINT_PATH is for the more complete Caddyfile.
-      - SPA_ENTRYPOINT_PATH=/index.html 
-      - LOG_LEVEL=DEBUG
+      SPA_ENTRYPOINT_PATH: "/index.html"
+      LOG_LEVEL: "DEBUG"
     networks:
       - caddy_test_net
 


### PR DESCRIPTION
On minikube, getting

```
{"level":"info","ts":1757006587.1971028,"msg":"using config from file","file":"/etc/caddy/Caddyfile"}
Error: adapting config using caddyfile: Unexpected next token after '{' on same line, at /etc/caddy/Caddyfile:27
```

- Logging statements are not the proper format. Going to rely on caddy's default logging.
- Docker-compose file wasn't passing in the env var right.
- Validating the caddyfile on pr.