### PR TITLE
feat: add manifest location environment variable and enhance Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -17,10 +17,48 @@
         respond "OK" 200
     }
 
+    # Handle manifest files specifically
+    @manifest_match {
+        path */fed-mods.json
+    }
+    handle @manifest_match {
+        # Set appropriate headers for manifest files
+        header Content-Type application/json
+        header Cache-Control "no-cache, no-store, must-revalidate"
+        header Pragma no-cache
+        header Expires 0
+
+        # Try to serve from operator-generated location first, then fallback to static locations
+        try_files {$MANIFEST_LOCATION:/srv/dist/operator-generated/fed-modules.json} {$BUCKET_PATH_PREFIX}/data{http.request.uri.path} {$BUCKET_PATH_PREFIX}/data/stable{http.request.uri.path} {$BUCKET_PATH_PREFIX}/data/preview{http.request.uri.path}
+        
+        reverse_proxy {$MINIO_UPSTREAM_URL} {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+        }
+    }
+
+    # Handle operator-generated fed-modules.json specifically
+    @operator_fed_modules {
+        path {$MANIFEST_LOCATION:/srv/dist/operator-generated/fed-modules.json}
+    }
+    handle @operator_fed_modules {
+        header Content-Type application/json
+        header Cache-Control "no-cache, no-store, must-revalidate"
+        header Pragma no-cache
+        header Expires 0
+
+        reverse_proxy {$MINIO_UPSTREAM_URL} {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+        }
+    }
+
     # Main request handling.
     # If incoming request is /app_name/filepath.ext
     # it will be rewritten to BUCKET_PATH_PREFIX/data/app_name/filepath.ext
-    handle {
+    @main_match {
+        not path */fed-mods.json
+        not path {$MANIFEST_LOCATION:/srv/dist/operator-generated/fed-modules.json}
+    }
+    handle @main_match {
         # Prepend BUCKET_PATH_PREFIX/data to the incoming request URI path
         rewrite * {$BUCKET_PATH_PREFIX}/data{http.request.uri.path}
         

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This component is part of an initiative to implement an object storage-based pus
 Key functionalities include:
 * Reverse proxying requests to S3/Minio.
 * Supporting Single Page Application (SPA) routing by ensuring that requests for non-existent asset paths correctly serve the main application entrypoint (e.g., `index.html`).
+* **Manifest file handling**: Special handling for `fed-mods.json` manifest files with appropriate caching headers and fallback locations.
+* **Operator-generated manifest support**: Prioritizes operator-generated manifest files when available via the `MANIFEST_LOCATION` environment variable.
 * Providing a flexible point for potential future processing of asset requests.
 * Designed to be deployed as a containerized application, managed by a Frontend Operator (FEO) within a Kubernetes environment (e.g., in the FEO namespace as a new managed resource).
 * Built and versioned using Konflux.
@@ -30,6 +32,7 @@ The proxy is configured primarily through the `Caddyfile`. Runtime behavior is c
 | `MINIO_UPSTREAM_URL`    | The base URL of the Minio/S3 service (scheme, host, port only).                | `http://minio:9000` (Docker Compose service name) | N/A                 | Yes      |
 | `BUCKET_PATH_PREFIX`    | The bucket name/path prefix to be prepended to requests (must start with `/`). | `/frontend-assets`                           | N/A                 | Yes      |
 | `SPA_ENTRYPOINT_PATH`   | Path to the SPA's entry HTML file within the bucket (e.g., `/index.html`).     | `/index.html`                                | `/index.html`       | No       |
+| `MANIFEST_LOCATION`     | Path to operator-generated fed-modules.json manifest file.                     | `/srv/dist/operator-generated/fed-modules.json` | `/srv/dist/operator-generated/fed-modules.json` | No |
 | `LOG_LEVEL`             | The log level for Caddy (DEBUG, INFO, WARN, ERROR).                      | `DEBUG`                                      | `DEBUG` (in Caddyfile) | No       |
 
 ## Included Files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       BUCKET_PATH_PREFIX: "/frontend-assets"
       # SPA_ENTRYPOINT_PATH is for the more complete Caddyfile.
       SPA_ENTRYPOINT_PATH: "/index.html"
+      # MANIFEST_LOCATION for operator-generated fed-modules.json
+      MANIFEST_LOCATION: "/srv/dist/operator-generated/fed-modules.json"
       LOG_LEVEL: "DEBUG"
     networks:
       - caddy_test_net


### PR DESCRIPTION
[RHCLOUD-41950](https://issues.redhat.com/browse/RHCLOUD-41950)- Add specific routing for manifest files (fed-mods.json) in Caddyfile 
- Set proper headers for manifest files (JSON content-type, no-cache)
- Add MANIFEST_LOCATION environment variable support
- Implement fallback logic for manifest file locations
- Exclude manifest files from regular app routes to prevent conflicts

*(assisted by Cursor)*