### PR TITLE
Corrects rewrite statement

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -27,11 +27,21 @@
 	}
 
 	# Main request handling.
-	# If incoming request is /app_name/filepath.ext
+	# If incoming request is /apps/app_name/filepath.ext
 	# it will be rewritten to BUCKET_PATH_PREFIX/data/app_name/filepath.ext
+	handle /apps/* {
+		# Strip /apps prefix and prepend BUCKET_PATH_PREFIX/data
+		rewrite /apps/* /{$BUCKET_PATH_PREFIX}/data/{path.1}
+
+		reverse_proxy {$MINIO_UPSTREAM_URL} {
+			header_up Host {http.reverse_proxy.upstream.hostport}
+		}
+	}
+
+	# Fallback for requests not starting with /apps
 	handle {
 		# Prepend BUCKET_PATH_PREFIX/data to the incoming request URI path
-		rewrite * /{$BUCKET_PATH_PREFIX}/data{http.request.uri.path.strip_prefix("/apps")}
+		rewrite * /{$BUCKET_PATH_PREFIX}/data{http.request.uri.path}
 
 		reverse_proxy {$MINIO_UPSTREAM_URL} {
 			header_up Host {http.reverse_proxy.upstream.hostport}

--- a/Caddyfile
+++ b/Caddyfile
@@ -29,9 +29,10 @@
 	# Main request handling.
 	# If incoming request is /apps/app_name/filepath.ext
 	# it will be rewritten to BUCKET_PATH_PREFIX/data/app_name/filepath.ext
-	handle /apps/* {
+	# hande_paths strips /apps from uri.path
+	handle_path /apps/* {
 		# Strip /apps prefix and prepend BUCKET_PATH_PREFIX/data
-		rewrite /apps/* /{$BUCKET_PATH_PREFIX}/data/{path.1}
+		rewrite * /{$BUCKET_PATH_PREFIX}/data{http.request.uri.path}
 
 		reverse_proxy {$MINIO_UPSTREAM_URL} {
 			header_up Host {http.reverse_proxy.upstream.hostport}


### PR DESCRIPTION
- Fixes rewrite statement to strip /apps and implant /data
- Left a fallback as a precaution

Test results on to the dummy http server give the proper paths (200 not expected here)

```
~/frontend-operator$ python -m http.server 9000
Serving HTTP on 0.0.0.0 port 9000 (http://0.0.0.0:9000/) ...
127.0.0.1 - - [19/Sep/2025 21:49:28] code 404, message File not found
127.0.0.1 - - [19/Sep/2025 21:49:28] "GET /frontends/data/my-app HTTP/1.1" 404 -
127.0.0.1 - - [19/Sep/2025 21:49:28] code 404, message File not found
127.0.0.1 - - [19/Sep/2025 21:49:28] "GET /frontends/data/my-app HTTP/1.1" 404 -
127.0.0.1 - - [19/Sep/2025 21:49:28] code 404, message File not found
127.0.0.1 - - [19/Sep/2025 21:49:28] "GET /frontends/manifests/app-manifest.json HTTP/1.1" 404 -

```